### PR TITLE
Wait until transfer completes and report that transfer is complete

### DIFF
--- a/GlobusArchiver.py
+++ b/GlobusArchiver.py
@@ -807,7 +807,7 @@ def check_task_for_success(transfer, task_id):
     if not transfer.task_wait(task_id, timeout=timeout):
         log_and_email(f"Transfer timed out after {timeout} seconds", logging.error)
     else:
-        log_and_email(f"Transfer complete.", logging.debug)
+        log_and_email(f"Transfer complete.", logging.info)
 
 def submit_transfer_task(transfer, tdata):
     try:

--- a/GlobusArchiver.py
+++ b/GlobusArchiver.py
@@ -131,7 +131,7 @@ archiveDateTimeFormats=["%Y%m%d","%Y%m%d%H","%Y-%m-%dT%H:%M:%SZ"]
 # You may want to keep the tmp area around for debugging
 # If this is set to True, the data will be scrubbed before
 # the archiver can send it
-cleanTemp = False
+cleanTemp = True
 
 # Set to False to process data but don't actually submit the tasks to Globus
 submitTasks = True


### PR DESCRIPTION
if it does complete. If it times out (controlled by transferStatusTimeout) then it adds an error that it timed out. Also set default value of cleanTemp to True since we can now clean out the temp data since it waits for the transfer to complete.

Q: Should it skip scrubbing the temp dir if it times out?